### PR TITLE
Add async client with gzip helper function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 
 [features]
 default = [ "client" ]
-client = []
+client = [ "flate2" ]
 
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+
+flate2 = { version = "1.0.16", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -197,8 +197,45 @@ impl ClientBuilder {
     }
 }
 
-mod r#async {
-    pub struct Client;
+/// An async implementation of the New Relic Telemetry SDK `Client`.
+pub mod r#async {
+    use anyhow::Result;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    pub struct Client {}
+
+    impl Client {
+        // Returns a gzip compressed version of the given string.
+        fn to_gzip(text: &String) -> Result<Vec<u8>> {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(text.as_bytes())?;
+            Ok(encoder.finish()?)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::Client;
+        use anyhow::Result;
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        #[test]
+        fn to_gzip() -> Result<()> {
+            let text = "Text to be encoded".to_string();
+            let encoded = Client::to_gzip(&text)?;
+
+            let mut gz = GzDecoder::new(&encoded[..]);
+            let mut decoded = String::new();
+            gz.read_to_string(&mut decoded)?;
+
+            assert_eq!(decoded, text);
+
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,6 @@ pub mod attribute;
 mod client;
 
 #[cfg(feature = "client")]
+pub use client::r#async;
+#[cfg(feature = "client")]
 pub use client::ClientBuilder;


### PR DESCRIPTION
This PR adds:
* An empty struct for the async client.
* A static gzip helper function for the client.

The helper function will be needed to send HTTP request with a gzipped body. From the [spec](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#request-format):
> SDKs **MUST** compress the JSON payload with `gzip` encoding by default.

I also use the term _client_ instead of _sender_. It is more in line with other Telemetry SDKs, as well as general HTTP terminology.

The mirrored PR with CI is [here](https://github.com/pyohannes/newrelic-telemetry-sdk-rust/pull/5).