### PR TITLE
Async client, part 1: Add method for response handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2018"
 
 [features]
 default = [ "client" ]
-client = [ "flate2" ]
+client = [ "flate2", "hyper" ]
 
 [dependencies]
 anyhow = "1.0"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 
+hyper = { version = "0.13", features = [], optional = true }
 flate2 = { version = "1.0.16", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This adds a method for handling HTTP responses from ingest endpoints. It aims to encapsulate [this part](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#response-codes) of the specification.

It mostly is based on [this part](https://source.datanerd.us/jtax/newrelic-telemetry-sdk-rust-prototype/blob/master/src/sender.rs#L211) of the original prototype, but refactors the functionality in a dedicated method to make it testable and better digestible for reviewers.

This builds on #10 and incorporates the changes in that PR.

That's the [mirrored PR with CI](https://github.com/pyohannes/newrelic-telemetry-sdk-rust/pull/6).