### PR TITLE
Add 128 int attribute value

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -24,6 +24,24 @@ pub enum Value {
     /// ```
     UInt(u64),
 
+    /// Represents a signed 128 bit integer attribute value.
+    ///
+    /// ```
+    /// # use newrelic_telemetry::attribute::Value;
+    /// #
+    /// let v = Value::Int128(-30);
+    /// ```
+    Int128(i128),
+
+    /// Represents an unsigned 128 bit integer attribute value.
+    ///
+    /// ```
+    /// # use newrelic_telemetry::attribute::Value;
+    /// #
+    /// let v = Value::UInt128(30);
+    /// ```
+    UInt128(u128),
+
     /// Represents a string attribute value.
     ///
     /// ```
@@ -52,6 +70,20 @@ pub enum Value {
     Bool(bool),
 }
 
+/// Converts an i128 to an attribute value.
+///
+/// ```
+/// # use newrelic_telemetry::attribute::Value;
+/// #
+/// let v: i128 = -10;
+/// assert_eq!(Value::Int128(-10), v.into());
+/// ```
+impl From<i128> for Value {
+    fn from(value: i128) -> Value {
+        Value::Int128(value)
+    }
+}
+
 /// Converts an i64 to an attribute value.
 ///
 /// ```
@@ -77,6 +109,20 @@ impl From<i64> for Value {
 impl From<i32> for Value {
     fn from(value: i32) -> Value {
         Value::Int(value as i64)
+    }
+}
+
+/// Converts a u128 to an attribute value.
+///
+/// ```
+/// # use newrelic_telemetry::attribute::Value;
+/// #
+/// let v: u128 = 50;
+/// assert_eq!(Value::UInt128(50), v.into());
+/// ```
+impl From<u128> for Value {
+    fn from(value: u128) -> Value {
+        Value::UInt128(value)
     }
 }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,5 +1,6 @@
 use crate::attribute::Value;
 use std::collections::HashMap;
+use std::time::Duration;
 
 /// Represents a distributed tracing span.
 #[derive(serde::Serialize, Debug, PartialEq)]
@@ -67,12 +68,12 @@ impl Span {
     }
 
     /// Set the duration (in milliseconds) of this span.
-    pub fn duration(self, duration: u64) -> Self {
-        self.attribute("duration.ms", duration)
+    pub fn duration(self, duration: Duration) -> Self {
+        self.attribute("duration.ms", duration.as_millis())
     }
 
-    pub fn set_duration(&mut self, duration: u64) {
-        self.set_attribute("duration.ms", duration);
+    pub fn set_duration(&mut self, duration: Duration) {
+        self.set_attribute("duration.ms", duration.as_millis());
     }
 
     /// Set the id of the previous caller of this span.
@@ -109,6 +110,7 @@ mod tests {
     use super::Span;
     use crate::attribute::Value;
     use serde_json::json;
+    use std::time::Duration;
 
     #[test]
     fn test_set_id() {
@@ -179,11 +181,11 @@ mod tests {
         );
 
         // Test duration attribute
-        span.set_duration(1);
-        assert_eq!(span.attributes.get("duration.ms"), Some(&Value::UInt(1)));
+        span.set_duration(Duration::from_millis(10));
+        assert_eq!(span.attributes.get("duration.ms"), Some(&Value::UInt128(10)));
 
-        span = span.duration(2);
-        assert_eq!(span.attributes.get("duration.ms"), Some(&Value::UInt(2)));
+        span = span.duration(Duration::from_millis(20));
+        assert_eq!(span.attributes.get("duration.ms"), Some(&Value::UInt128(20)));
 
         // Test parent id attribute
         span.set_parent_id("parent");


### PR DESCRIPTION
This expands the Attribute value enum to include the `i128` and `u128` integer types. I elected to have separate representations for the `128` type rather than follow the current converting up to the higher type that is used for the `i/u32` type (ex: `Int(i64)` takes the `i32` and casts it Into an `i64`). 

CI Run [here](https://github.com/Fahmy-Mohammed/newrelic-telemetry-sdk-rust/pull/5/checks?check_run_id=1013503091).