### PR TITLE
Add an integration test runner

### DIFF
--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "blocking")]
+#[macro_use]
 mod common;
 
 #[cfg(feature = "blocking")]
@@ -6,7 +7,7 @@ mod blocking {
     use super::common;
     use anyhow::Result;
     use common::Endpoint;
-    use newrelic_telemetry::{blocking::Client, ClientBuilder, SpanBatch};
+    use newrelic_telemetry::{blocking::Client, ClientBuilder, Span, SpanBatch};
     use std::thread;
     use std::time::Duration;
 
@@ -185,21 +186,14 @@ mod blocking {
 
     #[test]
     fn split_payload() -> Result<()> {
-        /*
         let (mut endpoint, client) = setup();
 
-        span_batch
-            .record(Span::new("id1").trace_id("tid1").timestamp(1000))
-            .unwrap();
-        span_batch
-            .record(Span::new("id2").trace_id("tid2").timestamp(2000))
-            .unwrap();
-        span_batch
-            .record(Span::new("id1").trace_id("tid1").timestamp(1000))
-            .unwrap();
-        span_batch
-            .record(Span::new("id2").trace_id("tid2").timestamp(2000))
-            .unwrap();
+        let mut span_batch = SpanBatch::new();
+
+        span_batch.record(Span::new("id1", "tid1", 1000));
+        span_batch.record(Span::new("id2", "tid2", 2000));
+        span_batch.record(Span::new("id1", "tid1", 1000));
+        span_batch.record(Span::new("id2", "tid2", 2000));
 
         client.send_spans(span_batch);
         endpoint.reply(413)?;
@@ -246,7 +240,6 @@ mod blocking {
 
         // Skip the first payload that is rejected.
         endpoint.next_payload()?.body;
-        */
 
         Ok(())
     }


### PR DESCRIPTION
This builds on top of #23 and adds an integration test runner, as well as integration tests for the blocking client (as far as that's possible without a working `SpanBatch`).

The integration runner spawns a background thread that runs an HTTP server. It allows to catch and validate any requests sent to that server.

This PR also adds basic tests (for the retry and backoff mechanisms, as well as for header validation).

You can find the mirrored PR with CI [here](https://github.com/pyohannes/newrelic-telemetry-sdk-rust/pull/10).