### PR TITLE
Update span attribute setters for reserved keys

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -1,6 +1,7 @@
 use crate::attribute::Value;
 use crate::client::Sendable;
 use anyhow::Result;
+use log::{error};
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
@@ -111,6 +112,8 @@ impl Span {
     pub fn attribute<T: Into<Value>>(mut self, key: &str, value: T) -> Self {
         if !self.is_reserved_key(&key) {
             self.attributes.insert(key.to_string(), value.into());
+        } else {
+            error!("Unable to add attribute. {} is a reserved key", key);
         }
         self
     }
@@ -118,6 +121,8 @@ impl Span {
     pub fn set_attribute<T: Into<Value>>(&mut self, key: &str, value: T) {
         if !self.is_reserved_key(&key) {
             self.attributes.insert(key.to_string(), value.into());
+        } else {
+            error!("Unable to add attribute. {} is a reserved key", key);
         }
     }
 
@@ -125,12 +130,7 @@ impl Span {
     /// used to ensure they aren't set using the attribute() and set_attribute()
     /// functions that won't guarantee the type of these reserved key:value pairs
     fn is_reserved_key(&self, key: &str) -> bool {
-        let list = ["name", "duration.ms", "parent.id", "service.name"];
-        if list.contains(&key) {
-            true
-        } else {
-            false
-        }
+        ["name", "duration.ms", "parent.id", "service.name"].contains(&key)
     }
 }
 


### PR DESCRIPTION
This PR removes the capability of the `attribute()` and `set_attribute()` _generic attribute setters_ to set the `name`, `parent.id`, `duration.ms`, and `service.name` _optional attributes_. Previously, these attributes were added using their own setters which used the generic attribute setters underneath. Without any checks in the generic attribute setters, the optional attributes could be set using their respective keys, but with a different type than expected. This has been changed to restrict setting the optional attributes in their respective setters by inserting directly into the attribute hashmap instead of using the generic attribute setters.

[CI run](https://github.com/Fahmy-Mohammed/newrelic-telemetry-sdk-rust/pull/6/checks?check_run_id=1028104671)