### PR TITLE
Issue #36: Remove SpanBatchCommon

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -143,7 +143,7 @@ impl From<Vec<Span>> for SpanBatch {
 }
 
 impl SpanBatch {
-    /// Creates a new `SpanBatch` with all collections empty.
+    /// Creates an empty `SpanBatch`.
     pub fn new() -> Self {
         SpanBatch {
             spans: vec![],


### PR DESCRIPTION
I have a better understanding for why `SpanBatchCommon` was introduced. It more closely matches the structure of the target JSON. Should the spec change and additional `common` attributes get added in, the approach used to serialize things here will need to be updated.

The current approach works because there are only `attributes` in the `common` section. The `serde` hook will likely need to move to the struct level should that ever not be the case.