### PR TITLE
Add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ What is the New Relic Rust Telemetry SDK?
 
 This SDK currently supports sending spans to the [Trace API](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api).
 
-**This project is currently in an alpha state.**
+**This project is currently in an alpha state.** The API of this crate is
+likely to change, therefore there's no API documentation available yet.
 
 ## Getting Started
 
@@ -59,7 +60,6 @@ async fn main() {
 ## Find and use your data
 
 Tips on how to find and query your data in New Relic:
-- [Find metric data](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data)
 - [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data)
 
 For general querying information, see:


### PR DESCRIPTION
This adds a README that aims to conform to the [template](https://github.com/newrelic/newrelic-repo-template/blob/main/README.md).

I'm not sure what words to best use to indicate the alpha state of the project. We basically want to indicate that this project is safe to use as a foundation for the C Telemetry SDK, but not as a pure Rust crate.
